### PR TITLE
Bulk SMS Endpoint Correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Below is a sample sendsms JSON data:
 ### SMS Responses Body:
 SMS Response(s):
 ```json
-1. Success
+1.Success
     [
         {
             "status_code": "1000",
@@ -43,7 +43,7 @@ SMS Response(s):
         }
     ]
 
-2. Failed
+2.Failed
     [
         {
             "status_code": "1003",

--- a/tilil/tilil.go
+++ b/tilil/tilil.go
@@ -10,7 +10,6 @@ import (
 
 const (
 	TILIL_SINGLE_SMS_ENDPOINT = "https://api.tililtech.com/sms/v3/sendsms"
-	TILIL_BULK_SMS_ENDPOINT   = "https://api.tililtech.com/sms/v3/sendmultiple"
 	TILIL_API_KEY             = "EQxcdrnes0T6ytoXm4i5IvMKwL1S9VbaqjBFpgzJhDuRUlWAZY3N28GP7CHOkf"
 	SENDER_ID                 = "2513"
 )
@@ -73,7 +72,7 @@ func SendBulkSMS(text string, phoneNumbers []string) {
 		panic(err)
 	}
 
-	responce, err := http.Post(TILIL_BULK_SMS_ENDPOINT, "aplication/json", bytes.NewBuffer(smsBody))
+	responce, err := http.Post(TILIL_SINGLE_SMS_ENDPOINT, "aplication/json", bytes.NewBuffer(smsBody))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
# What this PR does:
* Tilil changed their endpoints and removed their bulk SMS endpoint to just a single endpoint that serves both sending single and multiple text messages.
* Fix a bug on the README file